### PR TITLE
Fix label typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@
 
 ## [1.0.3] - 2021-05-09
 
-* Add average lable set
+* Add average label set
 
 ## [1.0.2] - 2021-05-09
 
-* Average lable rounded
+* Average label rounded
 * Optimization displayed when only max and min
 
 ## [1.0.1] - 2021-05-08

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Sparkline(
 Sparkline(
   data: data,
   averageLine: true,
-  averageLable: true,
+  averageLabel: true,
 ),
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,7 +24,7 @@ void main() {
               // gridLineLabelPrecision: 3,
               // enableGridLines: true,
               averageLine: true,
-              averageLable: true,
+              averageLabel: true,
               // kLine: ['max', 'min', 'first', 'last'],
               // // max: 50.5,
               // // min: 10.0,

--- a/lib/src/sparkline.dart
+++ b/lib/src/sparkline.dart
@@ -91,7 +91,7 @@ class Sparkline extends StatelessWidget {
     this.gridLinelabelPrefix = "",
     this.gridLineLabelPrecision = 3,
     this.averageLine = false,
-    this.averageLable = true,
+    this.averageLabel = true,
     this.kLine,
     this.backgroundColor,
   }) : super(key: key);
@@ -229,8 +229,8 @@ class Sparkline extends StatelessWidget {
   ///average Line
   final bool averageLine;
 
-  ///average Lable
-  final bool averageLable;
+  ///average Label
+  final bool averageLabel;
 
   ///backgroudColor
   final Color? backgroundColor;
@@ -268,7 +268,7 @@ class Sparkline extends StatelessWidget {
           max: max,
           min: min,
           averageLine: averageLine,
-          averageLable: averageLable,
+          averageLabel: averageLabel,
           kLine: kLine,
           backgroundColor: backgroundColor,
         ),
@@ -305,7 +305,7 @@ class _SparklinePainter extends CustomPainter {
     double? min,
     this.averageLine = false,
     this.kLine,
-    this.averageLable = true,
+    this.averageLabel = true,
     this.backgroundColor,
   })  : _max = max != null
             ? max
@@ -346,7 +346,7 @@ class _SparklinePainter extends CustomPainter {
   final String gridLinelabelPrefix;
   final int gridLineLabelPrecision;
   final bool averageLine;
-  final bool averageLable;
+  final bool averageLabel;
   final List? kLine;
   final Color? backgroundColor;
 
@@ -557,7 +557,7 @@ class _SparklinePainter extends CustomPainter {
         canvas.drawLine(
             Offset(dx, height / 2), Offset(dx, height / 2 + 1), paint1);
       }
-      if (averageLable) {
+      if (averageLabel) {
         var averageVal = dataPoints.reduce((a, b) => a + b) / dataPoints.length;
         String averageValText =
             averageVal.toStringAsPrecision(gridLineLabelPrecision);
@@ -703,7 +703,7 @@ class _SparklinePainter extends CustomPainter {
         gridLinelabelPrefix != old.gridLinelabelPrefix ||
         gridLineLabelPrecision != old.gridLineLabelPrecision ||
         averageLine != old.averageLine ||
-        averageLable != old.averageLable ||
+        averageLabel != old.averageLabel ||
         kLine != old.kLine ||
         backgroundColor != old.backgroundColor ||
         useCubicSmoothing != old.useCubicSmoothing;


### PR DESCRIPTION
From `lable` to `label`. 

Sadly, this is a breaking change and will require bumping the major version if [Semantic Versioning](https://semver.org/) is to be adhered.